### PR TITLE
docs: in-place update mode for the Google Form generator

### DIFF
--- a/survey/build-google-form.gs
+++ b/survey/build-google-form.gs
@@ -4,12 +4,22 @@
  * Builds a Google Form for one device variant DIRECTLY from the canonical
  * questions.json in mkadie/NeedsBoard, and links it to a responses Sheet.
  *
- * Setup:
+ * Setup (first time — create a new form):
  *   1. https://script.google.com -> New project -> paste this file.
- *   2. Set VARIANT_ID below.
+ *   2. Set VARIANT_ID below; leave FORM_ID blank.
  *   3. Run buildForm(). Authorize when prompted.
  *   4. Read the Execution log for the published URL, edit URL, and Sheet URL.
  *      Embed the form on the static site via Send -> <> (iframe).
+ *
+ * Refresh later (UPDATE the existing form in place — keeps its URL, embed, and
+ * responses Sheet):
+ *   - Paste the form's id into FORM_ID (from the edit URL:
+ *     https://docs.google.com/forms/d/<FORM_ID>/edit), then run buildForm().
+ *     It rewrites the title, description (incl. doc link), and questions on the
+ *     SAME form, so the tssfaa.com embed updates automatically — no re-embed.
+ *   - Caveat: a full question rebuild can add columns to the responses Sheet for
+ *     historical responses. For a tiny tweak (e.g. just the doc link), editing
+ *     the form's description by hand is simpler and leaves the Sheet untouched.
  *
  * To export a batch of responses for the feedback-integrate workflow:
  *   - paste the responses Sheet URL into RESPONSES_SHEET_URL, run exportBatch(),
@@ -18,6 +28,7 @@
 
 const QUESTIONS_URL = 'https://raw.githubusercontent.com/mkadie/NeedsBoard/main/docs/feedback/questions.json';
 const VARIANT_ID = 'involuntary-nonverbal-mvp';
+const FORM_ID = '';             // blank = create a new form; set to update an existing form in place
 const RESPONSES_SHEET_URL = ''; // paste after buildForm() logs it, then run exportBatch()
 
 function loadRegistry_() {
@@ -41,7 +52,17 @@ function buildForm() {
     throw new Error('Unknown variant "' + VARIANT_ID + '". Known: ' + Object.keys(reg.variants).join(', '));
   }
 
-  const form = FormApp.create('T-Rex Talk — ' + variant.title + ' feedback');
+  const updating = !!FORM_ID;
+  let form;
+  if (updating) {
+    form = FormApp.openById(FORM_ID);          // update the existing form in place
+    const items = form.getItems();
+    for (let i = items.length - 1; i >= 0; i--) form.deleteItem(items[i]); // clear old questions
+  } else {
+    form = FormApp.create('T-Rex Talk — ' + variant.title + ' feedback');
+  }
+
+  form.setTitle('T-Rex Talk — ' + variant.title + ' feedback');
   let desc = reg.intro;
   if (variant.docUrl) desc += '\n\n' + (reg.docLinkLabel || 'Read about this device') + ': ' + variant.docUrl;
   desc += '\n\nAnonymous. Everything is optional.';
@@ -57,13 +78,18 @@ function buildForm() {
     addItem_(form, q, opts);
   });
 
-  const ss = SpreadsheetApp.create('T-Rex Talk feedback — ' + variant.title);
-  form.setDestination(FormApp.DestinationType.SPREADSHEET, ss.getId());
+  if (!updating) {
+    const ss = SpreadsheetApp.create('T-Rex Talk feedback — ' + variant.title);
+    form.setDestination(FormApp.DestinationType.SPREADSHEET, ss.getId());
+    Logger.log('Responses Sheet: ' + ss.getUrl());
+  } else {
+    Logger.log('Updated existing form in place — responses Sheet and embed unchanged.');
+  }
 
+  Logger.log((updating ? 'Updated' : 'Created') + ' form.');
   Logger.log('Published URL : ' + form.getPublishedUrl());
   Logger.log('Edit URL      : ' + form.getEditUrl());
-  Logger.log('Responses Sheet: ' + ss.getUrl());
-  Logger.log('Embed: open the edit URL, Send -> <> to copy the iframe.');
+  if (!updating) Logger.log('Embed: open the edit URL, Send -> <> to copy the iframe.');
 }
 
 function addItem_(form, q, opts) {

--- a/survey_integration.md
+++ b/survey_integration.md
@@ -74,13 +74,18 @@ Zero backend. The form auto-creates a Google Sheet of responses.
 Use the Apps Script in [`survey/build-google-form.gs`](./survey/build-google-form.gs):
 
 1. Go to <https://script.google.com> → New project. Paste the script.
-2. Set `VARIANT_ID` at the top (e.g. `'involuntary-nonverbal-mvp'`).
+2. Set `VARIANT_ID` at the top (e.g. `'involuntary-nonverbal-mvp'`); leave
+   `FORM_ID` blank.
 3. Run `buildForm()`. Authorize when prompted.
 4. The Execution log prints the Form's **published URL**, **edit URL**, and the
    linked **Sheet URL**. The form is built entirely from the live questions.json.
 
-Re-run it whenever questions.json changes to rebuild the form (or hand-edit the
-Google Form for small tweaks — but prefer regenerating to stay in sync).
+**Refreshing later (in place):** to push question/intro changes to the form you
+already embedded — without creating a duplicate — paste its id into `FORM_ID`
+(from the edit URL `.../forms/d/<FORM_ID>/edit`) and run `buildForm()` again. It
+rewrites the same form, so the tssfaa.com embed updates with no re-embed. (For a
+one-line tweak like adding the doc link, just edit the form's description by hand
+— that leaves the responses Sheet untouched.)
 
 > Prefer not to script it? You can build the Google Form by hand from the
 > `form-<variant>.md` preview — but the script keeps it in sync for free.


### PR DESCRIPTION
Re-running `buildForm()` used to always `FormApp.create()` a brand-new form (new URL + new Sheet), orphaning an already-embedded/collecting form. Adds a **`FORM_ID`** constant:

- **blank** → create a new form + responses Sheet (unchanged).
- **set** → `openById`, clear items, and rewrite title, description (incl. the doc link), and questions **in place** — same URL, same embed, same responses Sheet, so the tssfaa.com embed updates with no re-embed.

Caveat documented: a full question rebuild can add columns to the responses Sheet for historical responses; for a one-line tweak, hand-editing the form description is still simpler. Updated `survey_integration.md` (Path A1) accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)